### PR TITLE
TA#79461 [18.0][FIX] Environment.manage compatibility for Odoo 18

### DIFF
--- a/base_attachment_object_storage/models/ir_attachment.py
+++ b/base_attachment_object_storage/models/ir_attachment.py
@@ -258,22 +258,21 @@ class IrAttachment(models.Model):
 
         Using a new Odoo Environment thus a new PG transaction.
         """
-        with api.Environment.manage():
-            if new_cr:
-                registry = odoo.modules.registry.Registry.new(self.env.cr.dbname)
-                with closing(registry.cursor()) as cr:
-                    try:
-                        yield self.env(cr=cr)
-                    except Exception:
-                        cr.rollback()
-                        raise
-                    else:
-                        # disable pylint error because this is a valid commit,
-                        # we are in a new env
-                        cr.commit()  # pylint: disable=invalid-commit
-            else:
-                # make a copy
-                yield self.env()
+        if new_cr:
+            registry = odoo.modules.registry.Registry.new(self.env.cr.dbname)
+            with closing(registry.cursor()) as cr:
+                try:
+                    yield self.env(cr=cr)
+                except Exception:
+                    cr.rollback()
+                    raise
+                else:
+                    # disable pylint error because this is a valid commit,
+                    # we are in a new env
+                    cr.commit()  # pylint: disable=invalid-commit
+        else:
+            # make a copy
+            yield self.env()
 
     def _move_attachment_to_store(self):
         self.ensure_one()


### PR DESCRIPTION
## Summary  
Fixes the `AttributeError: type object 'Environment' has no attribute 'manage'` error in the `do_in_new_env()` method when running object storage migrations.

## Problem
The module was using `api.Environment.manage()` which was deprecated and completely removed in Odoo 18.0, causing a critical error during attachment storage migration.

## Solution
- Remove the problematic `with api.Environment.manage():` context manager
- Preserve the exact same functionality by unindenting the enclosed code block
- Environment management is now handled automatically by Odoo 18

## Technical Details
In Odoo 18.0, environment management was simplified and the explicit `api.Environment.manage()` context manager is no longer needed. The functionality remains identical without it.

## Test plan
- [x] Module loads without AttributeError  
- [x] Environment context manager works correctly
- [ ] Object storage migration executes successfully